### PR TITLE
Set default active configuration to 0

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,7 +15,7 @@
         <payment>
             <zippayment>
                 <debug>1</debug>
-                <active>1</active>
+                <active>0</active>
                 <model>ZipMoneyGatewayFacade</model>
                 <title>Zip now, pay later</title>
                 <widget_region>au</widget_region>


### PR DESCRIPTION
On module install the Zip method is set as active "1" by default. All modules should be disabled by default and enabled by the user within the Magento admin system configuration. There shouldn't be an assumption that even though the module is installed and enabled that the payment method has been configured with API keys and ready to be used as an active payment method in the checkout. Currently if the Zip module is installed on a production site, the Zip method will appear in the checkout due to this default config even without API keys configured.