### PR TITLE
Replace Zend Client with Laminas

### DIFF
--- a/Model/Config/HealthCheck.php
+++ b/Model/Config/HealthCheck.php
@@ -4,7 +4,7 @@ namespace Zip\ZipPayment\Model\Config;
 
 use Magento\Framework\HTTP\Adapter\Curl;
 use Magento\Framework\HTTP\Adapter\CurlFactory;
-use Zend_Http_Client;
+use Laminas\Http\Request;
 
 /**
  * Admin Model of health check
@@ -158,7 +158,7 @@ class HealthCheck
                     $url = $apiConfig->getHost() . '/checkouts/' . $checkoutId;
                     $isAuEndpoint = true;
                 }
-                $curlObject->write(Zend_Http_Client::GET, $url, '1.1', $headers);
+                $curlObject->write(Request::METHOD_GET, $url, '1.1', $headers);
                 $response = $curlObject->read();
                 $sslVerified = $curlObject->getInfo(CURLINFO_SSL_VERIFYRESULT) == 0;
                 $httpCode = (int)$curlObject->getInfo(CURLINFO_HTTP_CODE);

--- a/Model/Config/HealthCheck.php
+++ b/Model/Config/HealthCheck.php
@@ -57,9 +57,9 @@ class HealthCheck
      */
     private $_curlFactory;
     /**
-     * @var \Zend\Uri\Uri
+     * @var \Laminas\Uri\Uri
      */
-    private $_zendUri;
+    private $_laminasUri;
 
     /**
      * @var \Magento\Directory\Model\CountryFactory
@@ -73,7 +73,7 @@ class HealthCheck
      * @param \Zip\ZipPayment\Model\Config $config
      * @param CurlFactory $curlFactory ,
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Zend\Uri\Uri $zendUri
+     * @param \Laminas\Uri\Uri $laminasUri
      * @param \Magento\Directory\Model\CountryFactory $countryFactory
      */
     public function __construct(
@@ -82,7 +82,7 @@ class HealthCheck
         \Zip\ZipPayment\Model\Config $config,
         CurlFactory $curlFactory,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Zend\Uri\Uri $zendUri,
+        \Laminas\Uri\Uri $laminasUri,
         \Magento\Directory\Model\CountryFactory $countryFactory
     ) {
         $this->_logger = $logger;
@@ -90,7 +90,7 @@ class HealthCheck
         $this->_config = $config;
         $this->_curlFactory = $curlFactory;
         $this->_storeManager = $storeManager;
-        $this->_zendUri = $zendUri;
+        $this->_laminasUri = $laminasUri;
         $this->_countryFactory = $countryFactory;
     }
 


### PR DESCRIPTION
Zend Client was deprecated in Magento 2.4.6 and needs to be replaced with Laminas to work correctly in Magento 2.4.6-p3