### PR TITLE
ZES-88. Cancel order when Zip charge fails; bump version to 1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to the Zip Payment module for Magento 2 are documented in this file.
+
+## 1.2.12
+
+### Fixed
+- **ZES-88: Order left in `pending` when a Zip charge fails.** The error-handling
+  guard in `Model/Charge::charge()` used `||` where it should have used `&&`, so the
+  condition was always true and the method rethrew the exception before reaching the
+  order-cancellation logic. As a result, a failed charge (e.g. HTTP 402 "account is
+  locked") left a `pending` order in Magento with no matching successful charge. The
+  order is now cancelled when the charge cannot be completed.
+- `Helper\Data::handleException()` returned an imploded string while all five call
+  sites destructured it with `list($apiError, $message, $logMessage)`, which yielded
+  `null` values. It now returns the array again, so the correct decline message
+  (e.g. "The payment was declined by Zip.") reaches the customer and the logs.

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -69,7 +69,7 @@ class Data extends AbstractHelper
      * Handles the api exception
      *
      * @param ApiException $e
-     * @return string
+     * @return array [$apiError, $message, $logMessage]
      */
     public function handleException($e)
     {
@@ -108,10 +108,9 @@ class Data extends AbstractHelper
             }
 
             $this->_logger->debug($logMessage);
-            return implode(' ', [$apiError, $message, $logMessage]); //changed due to warning - Return value is expected to be 'string', 'array' returned
-            #return [$apiError, $message, $logMessage];
+            return [$apiError, $message, $logMessage];
         }
-        return null;
+        return [null, null, null];
     }
 
     /**

--- a/Model/Charge.php
+++ b/Model/Charge.php
@@ -194,7 +194,7 @@ class Charge extends AbstractCheckout
         } catch (\Exception $e) {
             $errorMessage = $cancelOrderMessage = "Unexpected behavior ." . $e->getMessage();
             if (!$e instanceof \Zip\ZipPayment\MerchantApi\Lib\ApiException
-                || !$e instanceof \Magento\Framework\Exception\LocalizedException
+                && !$e instanceof \Magento\Framework\Exception\LocalizedException
             ) {
                 $this->_logger->alert($errorMessage);
                 throw $e;

--- a/Test/Unit/Model/ChargeTest.php
+++ b/Test/Unit/Model/ChargeTest.php
@@ -255,6 +255,110 @@ class ChargeTest extends \PHPUnit\Framework\TestCase
         $this->_chargeModel->charge();
     }
 
+    /**
+     * @test
+     * @group Zipmoney_ZipPayment
+     *
+     * Regression for ZES-88: when the charge API fails (e.g. HTTP 402 "account is
+     * locked"), the Magento order must be cancelled instead of being left as
+     * 'pending'. Previously the catch block's guard used `||` and was always true,
+     * so it rethrew before ever reaching cancelOrder().
+     */
+    public function testChargeCancelsOrderWhenApiExceptionThrown()
+    {
+        $objManager = new ObjectManager($this);
+
+        $helperMock = $this->getMockBuilder(ZipMoneyDataHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['handleException', 'cancelOrder'])
+            ->getMock();
+
+        $helperMock->expects(static::once())->method('handleException')
+            ->willReturn(['Account locked', 'The payment was declined by Zip.', 'log message']);
+
+        // The core assertion: the order gets cancelled exactly once on charge failure.
+        $helperMock->expects(static::once())->method('cancelOrder');
+
+        $chargesApiMock = $this->getMockBuilder(\Zip\ZipPayment\MerchantApi\Lib\Api\ChargesApi::class)
+            ->getMock();
+        $chargesApiMock->expects(static::any())->method('chargesCreate')
+            ->willThrowException(
+                new \Zip\ZipPayment\MerchantApi\Lib\ApiException('Account locked', 402)
+            );
+
+        $chargeModel = $objManager->getObject(
+            \Zip\ZipPayment\Model\Charge::class,
+            ['_helper' => $helperMock]
+        );
+        $chargeModel->setApi($chargesApiMock);
+
+        $orderMock = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
+            ->setMethods(['getId'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $orderMock->expects(static::any())->method('getId')->willReturn(1);
+        $chargeModel->setOrder($orderMock);
+
+        $thrown = null;
+        try {
+            $chargeModel->charge(null);
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            $thrown = $e;
+        }
+
+        static::assertNotNull($thrown, 'charge() must rethrow a LocalizedException when the API fails');
+    }
+
+    /**
+     * @test
+     * @group Zipmoney_ZipPayment
+     *
+     * Complements ZES-88: a genuinely unexpected exception (neither ApiException
+     * nor LocalizedException) must be rethrown as-is, and the order must NOT be
+     * cancelled - that path is intentionally left to the caller.
+     */
+    public function testChargeRethrowsUnknownExceptionWithoutCancellingOrder()
+    {
+        $objManager = new ObjectManager($this);
+
+        $helperMock = $this->getMockBuilder(ZipMoneyDataHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['handleException', 'cancelOrder'])
+            ->getMock();
+
+        // Neither handler is touched for an unknown exception type.
+        $helperMock->expects(static::never())->method('handleException');
+        $helperMock->expects(static::never())->method('cancelOrder');
+
+        $chargesApiMock = $this->getMockBuilder(\Zip\ZipPayment\MerchantApi\Lib\Api\ChargesApi::class)
+            ->getMock();
+        $chargesApiMock->expects(static::any())->method('chargesCreate')
+            ->willThrowException(new \RuntimeException('unexpected'));
+
+        $chargeModel = $objManager->getObject(
+            \Zip\ZipPayment\Model\Charge::class,
+            ['_helper' => $helperMock]
+        );
+        $chargeModel->setApi($chargesApiMock);
+
+        $orderMock = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
+            ->setMethods(['getId'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $orderMock->expects(static::any())->method('getId')->willReturn(1);
+        $chargeModel->setOrder($orderMock);
+
+        $thrown = null;
+        try {
+            $chargeModel->charge(null);
+        } catch (\RuntimeException $e) {
+            $thrown = $e;
+        }
+
+        static::assertNotNull($thrown, 'charge() must rethrow an unknown exception unchanged');
+        static::assertSame('unexpected', $thrown->getMessage());
+    }
+
     public function testPlaceOrder()
     {
         $quoteMock = $this->getQuoteMock();

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "zip/magento2",
     "description": "Zip Payment Module for Magento 2",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "type": "magento2-module",
     "license": [
         "OSL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
 */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Zip_ZipPayment" setup_version="1.2.11">
+    <module name="Zip_ZipPayment" setup_version="1.2.12">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
## Problem
A client reported an order created in Magento as `pending` with no matching successful charge. Zip logged `AccountAdapterException: This account is locked ... cannot be charged` (HTTP 402). The order (`YW121519810`) was placed, the charge failed, but the order stayed `pending`.

## Root cause
In `Model/Charge::charge()` the `catch` guard was:
```php
if (!$e instanceof ApiException || !$e instanceof LocalizedException) {
    $this->_logger->alert($errorMessage);
    throw $e;
}
```
An exception can never be both types, so at least one `!instanceof` is always true - the guard is always true - the method logged `ALERT: Unexpected behavior .[402] ...` and rethrew before reaching `cancelOrder()`. The order was never cancelled.

## Fix
- `Model/Charge.php`: `||` -> `&&`. Genuinely-unexpected exceptions are rethrown as-is, while `ApiException`/`LocalizedException` fall through to charge cancellation + order cancellation. This resolves the incident.
- `Helper/Data::handleException()`: returned an imploded string while all five callers (`Charge`, `Token`, `TransactionCancel/Capture/Refund`) destructure it via `list($apiError, $message, $logMessage)` - they were all silently getting `null`. Restored the array return so the correct decline message reaches the customer and logs.
- Bumped version 1.2.11 -> 1.2.12 (`composer.json`, `etc/module.xml`) and added `CHANGELOG.md`.
